### PR TITLE
Refactor stock page to use stock DAO helpers

### DIFF
--- a/lib/modules/stock_page.dart
+++ b/lib/modules/stock_page.dart
@@ -1,5 +1,6 @@
 // lib/modules/stock_page.dart
 import 'package:flutter/material.dart';
+
 import '../modules/db.dart';
 
 class StockPage extends StatefulWidget {
@@ -10,7 +11,7 @@ class StockPage extends StatefulWidget {
 }
 
 class _StockPageState extends State<StockPage> {
-  List<Map<String,dynamic>> _items = [];
+  List<Map<String, dynamic>> _items = [];
   final _itemCtrl = TextEditingController();
   final _qtyCtrl = TextEditingController();
 
@@ -21,68 +22,162 @@ class _StockPageState extends State<StockPage> {
   }
 
   Future<void> _load() async {
-    final db = await DBHelper.database;
-    final rows = await db.rawQuery('SELECT id, item_name, category, qty, unit, last_updated FROM stock ORDER BY item_name');
-    setState(() => _items = rows.map((r)=>Map<String,dynamic>.from(r)).toList());
+    final rows = await DBHelper.listStockItems();
+    setState(() => _items = rows);
   }
 
   Future<void> _upsert() async {
     final name = _itemCtrl.text.trim();
     final qty = int.tryParse(_qtyCtrl.text.trim()) ?? 0;
     if (name.isEmpty) return;
-    final db = await DBHelper.database;
-    final row = await db.rawQuery('SELECT id, qty FROM stock WHERE item_name=?', [name]);
-    if (row.isNotEmpty) {
-      final id = row.first['id'];
-	  final current = row.first['qty'] as int? ?? 0;
-	  final newQty = current + qty;      
-      await db.update('stock', {'qty': newQty, 'last_updated': DateTime.now().toIso8601String()}, where: 'id=?', whereArgs: [id]);
-    } else {
-      await db.insert('stock', {'item_name': name, 'category': '', 'qty': qty, 'unit': 'pcs', 'last_updated': DateTime.now().toIso8601String()});
-    }
-    _itemCtrl.clear(); _qtyCtrl.clear();
+    await DBHelper.upsertStockByName(itemName: name, deltaQty: qty);
+    _itemCtrl.clear();
+    _qtyCtrl.clear();
+    await _load();
+  }
+
+  Future<void> _adjust(int id, int delta) async {
+    await DBHelper.adjustStock(id: id, delta: delta);
     await _load();
   }
 
   @override
   void dispose() {
-    _itemCtrl.dispose(); _qtyCtrl.dispose(); super.dispose();
+    _itemCtrl.dispose();
+    _qtyCtrl.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFF0F57A3),
-      appBar: AppBar(title: const Text('Inventory / Stock'), backgroundColor: const Color(0xFF0F57A3)),
-      body: Column(children: [
-        Container(height: 100, color: const Color(0xFF0F57A3), child: Padding(padding: const EdgeInsets.all(12), child: Align(alignment: Alignment.bottomLeft, child: Text(widget.username, style: const TextStyle(color: Colors.white, fontSize: 16))))),
-        Expanded(child: Container(
-          color: const Color(0xFFF6F8FB),
-          padding: const EdgeInsets.all(12),
-          child: Column(children: [
-            Row(children: [
-              Expanded(child: TextFormField(controller: _itemCtrl, decoration: const InputDecoration(labelText: 'Item name'))),
-              const SizedBox(width: 8),
-              SizedBox(width: 100, child: TextFormField(controller: _qtyCtrl, decoration: const InputDecoration(labelText: 'Qty'), keyboardType: TextInputType.number)),
-              const SizedBox(width: 8),
-              ElevatedButton(onPressed: _upsert, child: const Text('Add')),
-            ]),
-            const SizedBox(height: 12),
-            Expanded(child: ListView.separated(
-              itemCount: _items.length,
-              separatorBuilder: (_,__)=>const Divider(),
-              itemBuilder: (ctx,i){
-                final it = _items[i];
-                return ListTile(
-                  title: Text(it['item_name'] ?? ''),
-                  subtitle: Text('Qty: ${it['qty'] ?? 0}  • ${it['unit'] ?? ''}'),
-                  trailing: Text(it['last_updated'] ?? ''),
-                );
-              }
-            )),
-          ]),
-        )),
-      ]),
+      appBar: AppBar(
+        title: const Text('Inventory / Stock'),
+        backgroundColor: const Color(0xFF0F57A3),
+      ),
+      body: Column(
+        children: [
+          Container(
+            height: 100,
+            color: const Color(0xFF0F57A3),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Align(
+                alignment: Alignment.bottomLeft,
+                child: Text(
+                  widget.username,
+                  style: const TextStyle(color: Colors.white, fontSize: 16),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Container(
+              color: const Color(0xFFF6F8FB),
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: _itemCtrl,
+                          decoration: const InputDecoration(
+                            labelText: 'Item name',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      SizedBox(
+                        width: 100,
+                        child: TextFormField(
+                          controller: _qtyCtrl,
+                          decoration: const InputDecoration(labelText: 'Qty'),
+                          keyboardType: TextInputType.number,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(onPressed: _upsert, child: const Text('Add')),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: DataTable(
+                          columnSpacing: 24,
+                          columns: const [
+                            DataColumn(label: Text('Item')),
+                            DataColumn(label: Text('Category')),
+                            DataColumn(label: Text('Qty')),
+                            DataColumn(label: Text('Unit')),
+                            DataColumn(label: Text('Last Updated')),
+                            DataColumn(label: Text('Actions')),
+                          ],
+                          rows: _items.map((it) {
+                            final qty = (it['qty'] as int?) ??
+                                (it['qty'] is num ? (it['qty'] as num).toInt() : 0);
+                            final rowId = (it['id'] as int?) ??
+                                (it['id'] is num ? (it['id'] as num).toInt() : null);
+                            final isLow = qty <= 5;
+                            return DataRow(
+                              color: isLow
+                                  ? MaterialStateProperty.resolveWith(
+                                      (_) => Colors.red.shade50,
+                                    )
+                                  : null,
+                              cells: [
+                                DataCell(Text(it['item_name']?.toString() ?? '')),
+                                DataCell(Text(it['category']?.toString() ?? '')),
+                                DataCell(
+                                  Text(
+                                    qty.toString(),
+                                    style: isLow
+                                        ? const TextStyle(
+                                            color: Colors.red,
+                                            fontWeight: FontWeight.bold,
+                                          )
+                                        : null,
+                                  ),
+                                ),
+                                DataCell(Text(it['unit']?.toString() ?? '')),
+                                DataCell(
+                                  Text(it['last_updated']?.toString() ?? ''),
+                                ),
+                                DataCell(
+                                  Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      IconButton(
+                                        icon: const Icon(Icons.remove),
+                                        onPressed: rowId == null
+                                            ? null
+                                            : () => _adjust(rowId, -1),
+                                      ),
+                                      IconButton(
+                                        icon: const Icon(Icons.add),
+                                        onPressed: rowId == null
+                                            ? null
+                                            : () => _adjust(rowId, 1),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated stock DAO helpers for listing items, upserting by name, and adjusting quantities
- refactor the stock page to render a scrollable data table backed by the DAO helpers
- add per-row increment/decrement buttons and highlight low-quantity stock in red

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad98bec30832f9d633e15894473bf